### PR TITLE
Edit `vertical-align` style for structured content hyperlinks

### DIFF
--- a/ext/css/structured-content.css
+++ b/ext/css/structured-content.css
@@ -200,7 +200,7 @@
 
 /* Links */
 .gloss-link-text {
-    vertical-align: middle;
+    vertical-align: baseline;
 }
 .gloss-link-external-icon {
     display: inline-block;


### PR DESCRIPTION
I submitted this edit to Yomitan as well. There's some detailed documentation in the [pull request](https://github.com/themoeway/yomitan/pull/279) over there.